### PR TITLE
componentize orderForm

### DIFF
--- a/src/components/AddOrder.js
+++ b/src/components/AddOrder.js
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
 import OrderDataService from "../services/OrderService";
+import OrderForm from './OrderForm'
 
-//const STATES = require('./states.json');
-import { STATES } from "./states.js";
-
-const AddOrder = () => {
+const AddOrder = (props) => {
+  const {existingOrder} = props;
+  
   const initialOrderState = {
     id: null,
     order_number: "",
@@ -12,14 +12,11 @@ const AddOrder = () => {
     usa_state: "",
     published: false,
   };
+
   const [exceptionMessage, setExceptionMessage] = useState();
-  const [order, setOrder] = useState(initialOrderState);
+  const [order, setOrder] = useState(existingOrder? existingOrder: initialOrderState);
   const [submitted, setSubmitted] = useState(false);
 
-  const handleInputChange = (event) => {
-    const { name, value } = event.target;
-    setOrder({ ...order, [name]: value }); 
-  };
 
   const saveOrder = () => {
     var data = {
@@ -40,14 +37,15 @@ const AddOrder = () => {
       })
       .catch((e) => {
         setExceptionMessage("You have a problem. " + e.message);
-        console.log("Debug exception",e);
+        console.log("Debug exception", e);
       });
-  }; 
+  };
 
   const newOrder = () => {
     setOrder(initialOrderState);
     setSubmitted(false);
   };
+
   if (exceptionMessage) {
     return (
       <div class="alert alert-warning" role="alert">
@@ -56,83 +54,27 @@ const AddOrder = () => {
     );
   }
 
-  return (
-    <div className="submit-form">
-      {submitted ? (
+  if (submitted && !existingOrder) {
+    
+    return (
+      <div className="submit-form">
         <div>
           <h4>You submitted successfully!</h4>
           <button className="btn btn-success" onClick={newOrder}>
-            Add
+            Add a new order
           </button>
         </div>
-      ) : (
-        <div>
-          <div className="form-group">
-            <label htmlFor="order_number">Order Number</label>
-            <input
-              type="text"
-              className="form-control"
-              id="order_number"
-              required
-              value={order.order_number}
-              onChange={handleInputChange}
-              name="order_number"
-            />
-          </div>
+      </div>
+    );
+  } else {
+    
+    return (
+      <div>
+      <OrderForm order={order} setOrder={setOrder} saveOrder={saveOrder}/>
 
-          <div className="form-group">
-            <label htmlFor="usa_state">US State</label>
-            <select
-              value={order.usa_state}
-              id="usa_state"
-              onChange={handleInputChange}
-              name="usa_state"
-            >
-              {STATES &&
-                STATES.map((state, index) => {
-                  return (
-                    <option value={state.name} key={index}>
-                      {state.name}
-                    </option>
-                  );
-                })}
-            </select>
-          </div>
-
-          <div className="form-group">
-            <label htmlFor="office_code">Congressional Office</label>
-            <select
-              value={order.office_code}
-              id="office_code"
-              onChange={handleInputChange}
-              name="office_code"
-              required
-            >
-              {STATES &&
-                order.usa_state &&
-                STATES.filter((state) => state.name === order.usa_state)[0][
-                  "districts"
-                ].map((district, index) => {
-                  return (
-                    <option value={district} key={index}>
-                      {district}
-                    </option>
-                  );
-                })}
-            </select>
-          </div>
-
-          <button
-            disabled={!order.order_number || !order.usa_state || !order.office_code}
-            onClick={saveOrder}
-            className="btn btn-success"
-          >
-            Submit
-          </button>
-        </div>
-      )}
-    </div>
-  );
+      </div>
+    );
+  }
 };
 
 export default AddOrder;

--- a/src/components/Order.js
+++ b/src/components/Order.js
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from "react";
 import OrderDataService from "../services/OrderService";
-import { baseURL } from "../http-common";
 
-import { STATES } from "./states.js";
+import OrderForm from "./OrderForm";
 
 const Order = (props) => {
   const initialOrderState = {
@@ -16,7 +15,7 @@ const Order = (props) => {
   };
   const [currentOrder, setCurrentOrder] = useState(initialOrderState);
   const [message, setMessage] = useState("");
-
+  const mode = "edit";
   const getOrder = (id) => {
     console.log("id", id);
     OrderDataService.get(id)
@@ -32,11 +31,6 @@ const Order = (props) => {
   useEffect(() => {
     getOrder(props.match.params.id);
   }, [props.match.params.id]);
-
-  const handleInputChange = (event) => {
-    const { name, value } = event.target;
-    setCurrentOrder({ ...currentOrder, [name]: value });
-  };
 
   const updatePublished = (status) => {
     var data = {
@@ -77,123 +71,21 @@ const Order = (props) => {
         console.log(e);
       });
   };
-  console.log(currentOrder);
+
   return (
     <div>
       {currentOrder ? (
-        <div className="edit-form">
-          <h4>Order</h4>
-          <form>
-            <div className="form-group">
-              <label htmlFor="order_number">Order Number</label>
-              <input
-                type="text"
-                className="form-control"
-                id="order_number"
-                name="order_number"
-                value={currentOrder.order_number}
-                onChange={handleInputChange}
-              />
-            </div>
-
-            <div className="form-group">
-              <label htmlFor="usa_state">US State</label>
-              <select
-                value={currentOrder.usa_state}
-                id="usa_state"
-                onChange={handleInputChange}
-                name="usa_state"
-              >
-                {STATES &&
-                  STATES.map((state, index) => {
-                    return (
-                      <option value={state.name} key={index}>
-                        {state.name}
-                      </option>
-                    );
-                  })}
-              </select>
-            </div>
-
-            <div className="form-group">
-              <label htmlFor="office_code">Congressional Office</label>
-              <select
-                value={currentOrder.office_code}
-                id="office_code"
-                onChange={handleInputChange}
-                name="office_code"
-                required
-              >
-                {/* {STATES &&
-                  currentOrder.usa_state &&
-                  STATES.filter(
-                    (state) => state.name === currentOrder.usa_state
-                  ).filter((d) => d) &&  (
-                 <option value={currentOrder.office_code}>
-                        {currentOrder.office_code}
-                      </option>)} */}
-                {STATES &&
-                  currentOrder.usa_state &&
-                  STATES.filter(
-                    (state) => state.name === currentOrder.usa_state
-                  )[0]["districts"].map((district, index) => {
-                    return (
-                      <option value={district} key={index}>
-                        {district}
-                      </option>
-                    );
-                  })}
-              </select>
-            </div>
-
-
-
-            <div className="form-group">
-              <label>QR Code</label>
-              {currentOrder.uuid}
-              <img
-                src={baseURL + "/qrcode/" + currentOrder.uuid}
-                alt="QR Code"
-              />
-            </div>
-
-            <div className="form-group">
-              <label>
-                <strong>Status:</strong>
-              </label>
-              {currentOrder.published ? "Published" : "Pending"}
-            </div>
-          </form>
-
-          {currentOrder.published ? (
-            <button
-              className="badge badge-primary mr-2"
-              onClick={() => updatePublished(false)}
-            >
-              UnPublish
-            </button>
-          ) : (
-            <button
-              className="badge badge-primary mr-2"
-              onClick={() => updatePublished(true)}
-            >
-              Publish
-            </button>
-          )}
-
-          <button className="badge badge-danger mr-2" onClick={deleteOrder}>
-            Delete
-          </button>
-
-          <button
-            type="submit"
-            className="badge badge-success"
-            onClick={updateOrder}
-          >
-            Update
-          </button>
+        <>
+          <OrderForm
+            order={currentOrder}
+            setOrder={setCurrentOrder}
+            saveOrder={updateOrder}
+            updatePublished={updatePublished}
+            deleteOrder={deleteOrder}
+            mode={mode}
+          />
           <p>{message}</p>
-        </div>
+        </>
       ) : (
         <div>
           <br />

--- a/src/components/OrderForm.js
+++ b/src/components/OrderForm.js
@@ -1,0 +1,126 @@
+import React from 'react';
+import { STATES } from "./states.js";
+import { baseURL } from "../http-common";
+const OrderForm = (props) => {
+const {order, setOrder, saveOrder,mode, updatePublished, deleteOrder} = props;
+
+  const handleInputChange = (event) => {
+    const { name, value } = event.target;
+    setOrder({ ...order, [name]: value });
+  };
+
+    return (
+<div>
+        <div className="form-group">
+          <label htmlFor="order_number">Order Number</label>
+          <input
+            type="text"
+            className="form-control"
+            id="order_number"
+            required
+            value={order.order_number}
+            onChange={handleInputChange}
+            name="order_number"
+          />
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="usa_state">US State</label>
+          <select
+            value={order.usa_state}
+            id="usa_state"
+            onChange={handleInputChange}
+            name="usa_state"
+          >
+            {STATES &&
+              STATES.map((state, index) => {
+                return (
+                  <option value={state.name} key={index}>
+                    {state.name}
+                  </option>
+                );
+              })}
+          </select>
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="office_code">Congressional Office</label>
+          <select
+            value={order.office_code}
+            id="office_code"
+            onChange={handleInputChange}
+            name="office_code"
+            required
+          >
+            {STATES &&
+              order.usa_state &&
+              STATES.filter((state) => state.name === order.usa_state)[0][
+                "districts"
+              ].map((district, index) => {
+                return (
+                  <option value={district} key={index}>
+                    {district}
+                  </option>
+                );
+              })}
+          </select>
+        </div>
+        
+        {mode==="edit"?<><div className="form-group">
+              <label>QR Code</label>
+              {order.uuid}
+              <img
+                src={baseURL + "/qrcode/" + order.uuid}
+                alt="QR Code"
+                align="right"
+              />
+            </div>
+              <div className="form-group">
+              <label>
+                <strong>Status:</strong>
+              </label>
+              {order.published ? "Published" : "Pending"}
+            </div>
+            
+            
+            
+           </> :null}
+           {order.published ? (
+            <button
+              className="btn badge-primary mr-2"
+              onClick={() => updatePublished(false)}
+                disabled={
+                  !order.order_number || !order.usa_state || !order.office_code
+                }
+            >
+              UnPublish
+            </button>
+          ) : (
+            <button
+              className="btn badge-primary mr-2"
+              onClick={() => updatePublished(true)}
+              disabled={
+                !order.order_number || !order.usa_state || !order.office_code
+              }
+            >
+              Publish
+            </button>
+          )}
+{mode==="edit" &&
+          <button className="btn badge-danger mr-2" onClick={deleteOrder}>
+            Delete
+          </button>
+}
+        <button
+          disabled={
+            !order.order_number || !order.usa_state || !order.office_code
+          }
+          onClick={saveOrder}
+          className="btn btn-success"
+        >
+          {mode==="edit"?"Update":"Submit"}
+        </button>
+      </div>
+    )}
+
+    export default OrderForm;

--- a/src/components/OrdersList.js
+++ b/src/components/OrdersList.js
@@ -105,7 +105,7 @@ const OrdersList = () => {
       <div className="col-md-6">
         <h4>Orders List</h4>
 
-        <table class="table">
+        <table className="table">
           <thead>
             <tr>
               <th scope="col">Order Number</th>
@@ -136,12 +136,7 @@ const OrdersList = () => {
               </label>{" "}
               {currentOrder.office_code}
             </div>
-            <div>
-              <label>
-                <strong>Congressional Office:</strong>
-              </label>{" "}
-              {currentOrder.uuid}
-            </div>
+           
             <div>
               <label>
                 <strong>Status:</strong>


### PR DESCRIPTION
Hi all,
This PR makes the form on `order` and `add` the same component, so if in the future we (for example) change how the offices list is populated, or use a combobox, or fix the UI problem with states with only one office, we only have to do it once.

I tested the add & edit buttons and they both work. I did not test the publish or delete button as my understanding is they haven't been implemented yet.

Please be brutal with comments on this, I feel like there might be some streamlining of logic that could be done here.