### PR TITLE
add friendlier error message if not logged in

### DIFF
--- a/src/components/OrdersList.js
+++ b/src/components/OrdersList.js
@@ -9,6 +9,7 @@ const OrdersList = () => {
   const [searchTitle, setSearchTitle] = useState("");
   const [popUpBox, setPopUpbox] = useState("none");
   const [errorMessage, setErrorMessage] = useState("");
+  const loginError = "You must be logged in to view this page";
 
   useEffect(() => {
     retrieveOrders();
@@ -27,8 +28,12 @@ const OrdersList = () => {
       })
       .catch((e) => {
         console.log(e);
-        setPopUpbox("block");
-        setErrorMessage(e.message);
+        if (e.response.status === 401) {
+          setErrorMessage(loginError);
+        } else {
+          setPopUpbox("block");
+          setErrorMessage(e.message);
+        }
       });
   };
 
@@ -75,8 +80,8 @@ const OrdersList = () => {
   const clearSearch = () => {
     refreshList();
     setSearchTitle("");
-    setErrorMessage("")
-  } 
+    setErrorMessage("");
+  };
 
   const orderTbody = (
     <tbody className="flag-group">
@@ -101,101 +106,107 @@ const OrdersList = () => {
     setPopUpbox("none");
   };
 
-  return (
-    <>
-      <div className="list row">
-        <div className="col-md-8">
-          <div className="input-group mb-3">
-            <input
-              type="text"
-              className="form-control"
-              placeholder="Search by order number"
-              value={searchTitle}
-              onChange={onChangeSearchTitle}
-            />
-            <div className="input-group-append">
-              <button
-                className="btn btn-outline-secondary"
-                type="button"
-                onClick={findByOrderNumber}
-              >
-                Search
-              </button>
+  if (errorMessage === loginError) {
+    return errorMessage;
+  } else
+    return (
+      <>
+        <div className="list row">
+          <div className="col-md-8">
+            <div className="input-group mb-3">
+              <input
+                type="text"
+                className="form-control"
+                placeholder="Search by order number"
+                value={searchTitle}
+                onChange={onChangeSearchTitle}
+              />
+              <div className="input-group-append">
+                <button
+                  className="btn btn-outline-secondary"
+                  type="button"
+                  onClick={findByOrderNumber}
+                >
+                  Search
+                </button>
+              </div>
             </div>
           </div>
-        </div>
-        <div className="col-md-6">
-          <h4>Orders List</h4>
+          <div className="col-md-6">
+            <h4>Orders List</h4>
 
-          <table className="table">
-            <thead>
-              <tr>
-                <th scope="col">Order Number</th>
-                <th scope="col">USA State</th>
-                <th scope="col">Congressional Office</th>
-              </tr>
-            </thead>
-            {errorMessage ? errorMessage : orderTbody}
-          </table>
-          {errorMessage || searchTitle ? (
-            <button className="m-3 btn btn-sm btn-danger" onClick={clearSearch}>
-              Clear search
-            </button>
-          ) : (
-            <button
-              className="m-3 btn btn-sm btn-danger"
-              onClick={removeAllOrders}
-            >
-              Remove All
-            </button>
-          )}
-        </div>
-        <div className="col-md-6">
-          {currentOrder ? (
-            <div>
-              <h4>Order</h4>
-              <div>
-                <label>
-                  <strong>Order Number:</strong>
-                </label>{" "}
-                {currentOrder.order_number}
-              </div>
-              <div>
-                <label>
-                  <strong>Congressional Office:</strong>
-                </label>{" "}
-                {currentOrder.home_office_code}
-              </div>
-
-              <div>
-                <label>
-                  <strong>Status:</strong>
-                </label>{" "}
-                {currentOrder.published ? "Published" : "Pending"}
-              </div>
-
-              <Link
-                to={"/orders/" + currentOrder.uuid}
-                className="badge badge-warning"
+            <table className="table">
+              <thead>
+                <tr>
+                  <th scope="col">Order Number</th>
+                  <th scope="col">USA State</th>
+                  <th scope="col">Congressional Office</th>
+                </tr>
+              </thead>
+              {orderTbody}
+            </table>
+            {errorMessage || searchTitle ? (
+              <button
+                className="m-3 btn btn-sm btn-danger"
+                onClick={clearSearch}
               >
-                Edit
-              </Link>
-            </div>
-          ) : (
-            <div>
-              <br />
-              <p>Please click on an order...</p>
-            </div>
-          )}
+                Clear search
+              </button>
+            ) : (
+              <button
+                className="m-3 btn btn-sm btn-danger"
+                onClick={removeAllOrders}
+              >
+                Remove All
+              </button>
+            )}
+          </div>
+          <div className="col-md-6">
+            {currentOrder ? (
+              <div>
+                <h4>Order</h4>
+                <div>
+                  <label>
+                    <strong>Order Number:</strong>
+                  </label>{" "}
+                  {currentOrder.order_number}
+                </div>
+                <div>
+                  <label>
+                    <strong>Congressional Office:</strong>
+                  </label>{" "}
+                  {currentOrder.home_office_code}
+                </div>
+
+                <div>
+                  <label>
+                    <strong>Status:</strong>
+                  </label>{" "}
+                  {currentOrder.published ? "Published" : "Pending"}
+                </div>
+
+                <Link
+                  to={"/orders/" + currentOrder.uuid}
+                  className="badge badge-warning"
+                >
+                  Edit
+                </Link>
+              </div>
+            ) : (
+              <div>
+                <br />
+                <p>Please click on an order...</p>
+              </div>
+            )}
+          </div>
         </div>
-      </div>
-      <div className="pop-container" style={{ display: popUpBox }}>
-        <div className="pop-up" onClick={closePopUpBox}>
-          <h3>{errorMessage}</h3>
+        <div className="pop-container" style={{ display: popUpBox }}>
+          <div className="pop-up" onClick={closePopUpBox}>
+            <h3>{errorMessage}</h3>
+          </div>
         </div>
-      </div>
-    </>
-  );
+      </>
+    );
 };
 
 export default OrdersList;


### PR DESCRIPTION
I didn't see an open issue for this, but it was bugging me (and I'm not able to log in successfully with the current build of the backend, so this was something I could work on.)
Instead of displaying a modal (that's unclear if you can click it to dismiss), now loading the main page while not logged in displays a specific error message upon receiving a 401 code from the server, and also clears the "skeleton" of the orders list.
I think this is better behavior but would like to know what the group thinks. :)