### PR TITLE
Force refresh to display correct header upon login

### DIFF
--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -31,24 +31,21 @@ const Login = (props) => {
   const handleLogin = (e) => {
     e.preventDefault();
 
-    const serviceCall = () => {
-      return AuthService.login(username, password).then(
-        () => {
-          props.history.push("/");
-          props.history.go();
-        },
-        (error) => {
-          const resMessage =
-            (error.response &&
-              error.response.data &&
-              error.response.data.message) ||
-            error.message ||
-            error.toString();
-          setMessage(resMessage);
-        }
-      );
-    };
-    AuthService.refreshTokenWrapperFunction(serviceCall);
+    return AuthService.login(username, password).then(
+      () => {
+        props.history.push("/");
+        props.history.go();
+      },
+      (error) => {
+        const resMessage =
+          (error.response &&
+            error.response.data &&
+            error.response.data.message) ||
+          error.message ||
+          error.toString();
+        setMessage(resMessage);
+      }
+    );
   };
 
   return (

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -31,20 +31,24 @@ const Login = (props) => {
   const handleLogin = (e) => {
     e.preventDefault();
 
-    AuthService.login(username, password).then(
-      () => {
-        props.history.push("/");
-      },
-      (error) => {
-        const resMessage =
-          (error.response &&
-            error.response.data &&
-            error.response.data.message) ||
-          error.message ||
-          error.toString();
-        setMessage(resMessage);
-      }
-    );
+    const serviceCall = () => {
+      return AuthService.login(username, password).then(
+        () => {
+          props.history.push("/");
+          props.history.go();
+        },
+        (error) => {
+          const resMessage =
+            (error.response &&
+              error.response.data &&
+              error.response.data.message) ||
+            error.message ||
+            error.toString();
+          setMessage(resMessage);
+        }
+      );
+    };
+    AuthService.refreshTokenWrapperFunction(serviceCall);
   };
 
   return (

--- a/src/services/OrderService.js
+++ b/src/services/OrderService.js
@@ -4,18 +4,8 @@ import { httpAuthenticate } from "../http-common";
 
 /* remember also the api/qrcode img API*/
 
-const http2 = (func) => {
-  const retval = func();
-  console.log("debug", retval);
-  return retval;
-};
-
 const getAll = () => {
-  const requestFunc = () => {
-    return httpAuthenticate().get("/orders");
-  };
-
-  return http2(requestFunc);
+  return httpAuthenticate().get("/orders");
 };
 
 const get = (uuid) => {


### PR DESCRIPTION
Teensy weensy change here, just forcing the page to refresh upon login rather than relying on `props.history.push()` because the latter results in the public header being shown one too many times.

Is there a more elegant way to accomplish this? Thought about putting the entire header inside a UseEffect hook, with `user.username` as a dependency, but I don't love that either.

I also cleaned up some stuff left over from the authtoken logic that had inadvertently been left behind!

