### PR TITLE
add very basic password changing

### DIFF
--- a/src/components/passwordUpdate.js
+++ b/src/components/passwordUpdate.js
@@ -50,7 +50,8 @@ const PasswordUpdate = () => {
             } else {
               setMessage("An error occurred: " + response.statusText);
             }
-          });
+          })
+          .catch((err) => setMessage(""));
       };
       try {
         AuthService.refreshTokenWrapperFunction(serviceCall);

--- a/src/components/passwordUpdate.js
+++ b/src/components/passwordUpdate.js
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import userService from "../service/userService";
+import AuthService from "../service/authService";
+
+const PasswordUpdate = () => {
+  const [oldPassword, setOldPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [newPassword2, setNewPassword2] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleChange = (e) => {
+    let { name, value } = e;
+    if (e.target) {
+      name = e.target.name;
+      value = e.target.value;
+    }
+    switch (name) {
+      case "oldPassword":
+        setOldPassword(value);
+        break;
+      case "newPassword":
+        setNewPassword(value);
+        break;
+      case "newPassword2":
+        setNewPassword2(value);
+        break;
+      default:
+        break;
+    }
+  };
+  const comparePasswords = (newPass, newPass2) => {
+    return newPass == newPass2;
+  };
+
+  const submitHandler = (e) => {
+    e.preventDefault();
+    if (comparePasswords(newPassword, newPassword2)) {
+      const serviceCall = () => {
+        return userService
+          .updateOwnPassword({
+            newPassword: newPassword,
+            oldPassword: oldPassword,
+          })
+          .then((response) => {
+            if (response.status === 200) {
+              setOldPassword("");
+              setNewPassword("");
+              setNewPassword2("");
+              setMessage("Password updated successfully.");
+            } else {
+              setMessage("An error occurred: " + response.statusText);
+            }
+          });
+      };
+      try {
+        AuthService.refreshTokenWrapperFunction(serviceCall);
+      } catch (e) {
+        console.log(`error occurred while updating password: ${e}`);
+        setMessage("");
+      }
+    } else {
+      setMessage("New passwords must match!");
+    }
+  };
+
+  return (
+    <form onSubmit={submitHandler}>
+      <label htmlFor="oldPassword">Type your current password here...</label>
+      <input
+        type="password"
+        name="oldPassword"
+        value={oldPassword}
+        onChange={handleChange}
+      ></input>
+      <p>&nbsp;</p>
+      <label htmlFor="newPassword">Enter your new password...</label>
+      <input
+        type="password"
+        name="newPassword"
+        value={newPassword}
+        onChange={handleChange}
+      ></input>
+      <p>&nbsp;</p>
+      <label htmlFor="newPassword2">Confirm your new password...</label>
+      <input
+        type="password"
+        name="newPassword2"
+        value={newPassword2}
+        onChange={handleChange}
+      ></input>
+      <p>&nbsp;</p>
+      <input type="submit"></input>
+      {message}
+    </form>
+  );
+};
+
+export default PasswordUpdate;

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -59,10 +59,9 @@ const Profile = (props) => {
             }
           })}
       </ul>
-      <p>
-        <strong>Update password:</strong>
-        <PasswordUpdate />
-      </p>
+      <br />
+      <strong>Update password:</strong>
+      <PasswordUpdate />
     </div>
   );
 };

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -1,9 +1,9 @@
 import React from "react";
 import AuthService from "../service/authService";
+import PasswordUpdate from "../components/passwordUpdate";
 
 const Profile = (props) => {
   const currentUser = AuthService.getCurrentUser();
-  
 
   const roles = Object.fromEntries(
     Object.entries(currentUser).filter(([key]) =>
@@ -59,6 +59,10 @@ const Profile = (props) => {
             }
           })}
       </ul>
+      <p>
+        <strong>Update password:</strong>
+        <PasswordUpdate />
+      </p>
     </div>
   );
 };

--- a/src/service/userService.js
+++ b/src/service/userService.js
@@ -24,6 +24,13 @@ class UserService {
   getUsers() {
     return httpAuthenticate().get("users");
   }
+
+  updateOwnPassword({ newPassword, oldPassword }) {
+    const data = { new_password: newPassword, old_password: oldPassword };
+    return httpAuthenticate().post("/users/self/update/password", {
+      data,
+    });
+  }
 }
 
 export default new UserService();


### PR DESCRIPTION
This implements update_own_password on the frontend, but fails silently on a few error cases (as mentioned in the corresponding backend PR, [120](https://github.com/codefordc/us-congress-pizza-flag-tracker/pull/120).

-If the user isn't properly authenticated[^1] the action fails silently.
-If the user's current password doesn't match what was typed in the "current password" box the action fails silently.
As far as I understand it we're currently not passing error codes from the backend in a way that would make it possible to make these actions fail with visible errors, but I'm not the greatest at Flask so totally could be missing something. 

This whole component could probably use some better styling, if someone wants to take a crack at that!

[^1]: I haven't been able to reliably replicate this, but it seems like about 50% of the time, get_current_user() fails and returns an empty object. It's entirely possible this bug is related to just restarting the Flask server over and over again while testing, in which case it's (probably) a non-issue in production. But keep an eye out.

