### PR TITLE
move frontend error handling to separate function

### DIFF
--- a/src/components/handleError.js
+++ b/src/components/handleError.js
@@ -1,0 +1,7 @@
+export const handleError = (error, setMessage) => {
+  const resMessage =
+    (error.response && error.response.data && error.response.data.message) ||
+    error.message ||
+    error.toString();
+  setMessage(resMessage);
+};

--- a/src/components/passwordUpdate.js
+++ b/src/components/passwordUpdate.js
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import userService from "../service/userService";
 import AuthService from "../service/authService";
+import { handleError } from "./handleError";
 
 const PasswordUpdate = () => {
   const [oldPassword, setOldPassword] = useState("");
@@ -51,13 +52,13 @@ const PasswordUpdate = () => {
               setMessage("An error occurred: " + response.statusText);
             }
           })
-          .catch((err) => setMessage(""));
+          .catch((err) => handleError(err, setMessage));
       };
       try {
         AuthService.refreshTokenWrapperFunction(serviceCall);
       } catch (e) {
         console.log(`error occurred while updating password: ${e}`);
-        setMessage("");
+        handleError(e, setMessage);
       }
     } else {
       setMessage("New passwords must match!");

--- a/src/pages/editOrder.js
+++ b/src/pages/editOrder.js
@@ -4,6 +4,7 @@ import OrderDataService from "../service/orderService";
 import StatusDataService from "../service/statusService";
 import OrderForm from "../components/orderForm";
 import { numSort } from "../components/sorting/sortHook";
+import { handleError } from "../components/handleError";
 
 const EditOrder = (props) => {
   const initialOrderState = {
@@ -49,7 +50,7 @@ const EditOrder = (props) => {
     try {
       AuthService.refreshTokenWrapperFunction(serviceCall);
     } catch (e) {
-      console.log(e);
+      handleError(e, setMessage);
     }
   };
 
@@ -68,15 +69,7 @@ const EditOrder = (props) => {
     } catch (e) {
       setPopUpBox("block");
       console.log(e);
-      if (e.response.status === 401) {
-        setMessage(loginError);
-      } else {
-        setMessage(
-          e.message +
-            "." +
-            "Check with admin if server is down or try logging out and logging in."
-        );
-      }
+      handleError(e, setMessage);
     }
   };
 
@@ -101,7 +94,7 @@ const EditOrder = (props) => {
     try {
       AuthService.refreshTokenWrapperFunction(serviceCall);
     } catch (e) {
-      console.log(`error occurred while updating order: ${e}`);
+      handleError(e, setMessage);
     }
   };
 
@@ -114,7 +107,7 @@ const EditOrder = (props) => {
     try {
       AuthService.refreshTokenWrapperFunction(serviceCall);
     } catch (e) {
-      console.log(e);
+      handleError(e, setMessage);
     }
   };
 

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import Form from "react-validation/build/form";
 import Input from "react-validation/build/input";
 import CheckButton from "react-validation/build/button";
+import { handleError } from "../components/handleError";
 import styles from "../style/login.module.css";
 
 import AuthService from "../service/authService";
@@ -38,13 +39,7 @@ const Login = (props) => {
         props.history.go();
       },
       (error) => {
-        const resMessage =
-          (error.response &&
-            error.response.data &&
-            error.response.data.message) ||
-          error.message ||
-          error.toString();
-        setMessage(resMessage);
+        handleError(error, setMessage);
       }
     );
   };

--- a/src/pages/scanOrder.js
+++ b/src/pages/scanOrder.js
@@ -4,7 +4,7 @@ import OrderDataService from "../service/orderService";
 import StatusDataService from "../service/statusService";
 import { numSort } from "../components/sorting/sortHook";
 import styles from "../style/scanOrder.module.css";
-import handleError from "../components/handleError";
+import { handleError } from "../components/handleError";
 
 const ScanOrder = (props) => {
   const initialOrderState = {

--- a/src/pages/scanOrder.js
+++ b/src/pages/scanOrder.js
@@ -4,7 +4,8 @@ import OrderDataService from "../service/orderService";
 import StatusDataService from "../service/statusService";
 import { numSort } from "../components/sorting/sortHook";
 import styles from "../style/scanOrder.module.css";
-import { handleError } from "../components/handleError";
+import handleError from "../components/handleError";
+import { set } from "cypress/types/lodash";
 
 const ScanOrder = (props) => {
   const initialOrderState = {
@@ -44,13 +45,13 @@ const ScanOrder = (props) => {
           setOldOrder(response.data);
         })
         .catch((e) => {
-          handleError(e, setMessage);
+          console.log(e);
         });
     };
     try {
       AuthService.refreshTokenWrapperFunction(serviceCall);
     } catch (e) {
-      handleError(e, setMessage);
+      console.log(e);
     }
   };
 
@@ -69,6 +70,7 @@ const ScanOrder = (props) => {
     } catch (e) {
       setPopUpBox("block");
       console.log(e);
+
       handleError(e, setMessage);
     }
   };
@@ -207,9 +209,7 @@ const ScanOrder = (props) => {
 
   const refuseUpdate = () => {
     setPopUpBox("block");
-    setMessage(
-      "Do not have permissions for either (1) this order or (2) to advance to the next status"
-    );
+    handleError(e, setMessage);
   };
 
   const closePopUpBox = () => {

--- a/src/pages/scanOrder.js
+++ b/src/pages/scanOrder.js
@@ -5,7 +5,6 @@ import StatusDataService from "../service/statusService";
 import { numSort } from "../components/sorting/sortHook";
 import styles from "../style/scanOrder.module.css";
 import handleError from "../components/handleError";
-import { set } from "cypress/types/lodash";
 
 const ScanOrder = (props) => {
   const initialOrderState = {

--- a/src/pages/scanOrder.js
+++ b/src/pages/scanOrder.js
@@ -208,7 +208,7 @@ const ScanOrder = (props) => {
 
   const refuseUpdate = () => {
     setPopUpBox("block");
-    handleError(e, setMessage);
+    handleError("Do not have permissions for either (1) this order or (2) to advance to the next status", setMessage);
   };
 
   const closePopUpBox = () => {


### PR DESCRIPTION
I hope this is what @ethanstrominger meant on Wednesday--I've moved frontend error handling to a standalone function that can be called from any component or page. I SUSPECT that this change might actually break some of our existing error handling (because we were grabbing statuses and messages all willy nilly) but, as is apparently typical for me, I haven't fully tested it. (This would be a great cypress use case. ;)) I think ultimately this move is for the best because we'll be able to change how we respond to backend responses in one place instead of all over the code, making it less brittle in the long run--but there might be some growing pains in the meantime.