### PR TITLE
hacky way of hopefully fixing errors

### DIFF
--- a/src/components/LogTable.js
+++ b/src/components/LogTable.js
@@ -1,34 +1,7 @@
 import { React, useEffect, useState } from "react";
-import OrderDataService from "../service/orderService";
-import AuthService from "../service/authService";
 
 export const LogTable = (props) => {
-  const order_number = props.order_number;
-
-  const getOrderLog = (order_number) => {
-    const serviceCall = () => {
-      return OrderDataService.getOrderLog(order_number)
-        .then((response) => {
-          setOrderLog(response.data);
-        })
-        .catch((e) => {
-          console.log(e);
-        });
-    };
-    try {
-      AuthService.refreshTokenWrapperFunction(serviceCall);
-    } catch (e) {
-      console.log(e);
-    }
-  };
-
-  const [orderLog, setOrderLog] = useState();
-
-  useEffect(() => {
-    if (!orderLog) {
-      getOrderLog(order_number);
-    }
-  });
+  const orderLog = props.orderLog;
 
   return (
     <>

--- a/src/components/scanOrder/infoBottom.js
+++ b/src/components/scanOrder/infoBottom.js
@@ -1,7 +1,9 @@
-import { React, useState } from "react";
+import { React, useState, useEffect } from "react";
 import OrderClosed from "./infoBottom/orderClosed";
 import OrderOpen from "./infoBottom/orderOpen";
 import { LogTable } from "../LogTable";
+import OrderDataService from "../../service/orderService";
+import AuthService from "../../service/authService";
 
 const InfoBottom = (props) => {
   const {
@@ -22,6 +24,32 @@ const InfoBottom = (props) => {
   } = props;
 
   const [showLog, setShowLog] = useState(false);
+  const order_number = props.order.order_number;
+
+  const getOrderLog = (order_number) => {
+    const serviceCall = () => {
+      return OrderDataService.getOrderLog(order_number)
+        .then((response) => {
+          setOrderLog(response.data);
+        })
+        .catch((e) => {
+          console.log(e);
+        });
+    };
+    try {
+      AuthService.refreshTokenWrapperFunction(serviceCall);
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+  const [orderLog, setOrderLog] = useState();
+
+  useEffect(() => {
+    if (!orderLog) {
+      getOrderLog(order_number);
+    }
+  });
 
   return (
     <>
@@ -60,9 +88,7 @@ const InfoBottom = (props) => {
         >
           {showLog ? "Hide" : "Show"} flag history
         </button>
-        {showLog && (
-          <LogTable uuid={order.uuid} order_number={order.order_number} />
-        )}
+        {showLog && <LogTable uuid={order.uuid} orderLog={orderLog} />}
       </>
     </>
   );


### PR DESCRIPTION
OK so we were running into problems when running the old version of this code live on Heroku, presumably because Heroku is slower than running the db locally. The "correct" way to fix this would be to have an isLoading state and set a spinner. To be perfectly honest I don't feel like doing that tonight, and I'm not even sure how to do it with Axios. 
The workaround that I think will work is to move the logic for fetching the order logs to the parent level component so that the fetch begins a couple ms before the user clicks the show button. Like I said, hacky, but I'd love to not have giant bugs when we present next week :)