### PR TITLE
give more air to the order tile

### DIFF
--- a/src/style/orders.module.css
+++ b/src/style/orders.module.css
@@ -86,8 +86,7 @@ label {
   margin-bottom: 4vh;
   background-color: white;
   display: grid;
-  grid-template-columns: 60% 40%;
-  grid-template-rows: 35% 65%;
+  grid-template-columns: 20% 80%;
 }
 
 


### PR DESCRIPTION
This is a really small PR that adjusts the way the tiles look when they have gauges with more than ~5 items in them.
Tweaks to the layout made the gauge tiles overlap other important information.

Before:
![Screen Shot 2022-07-31 at 4 39 38 PM](https://user-images.githubusercontent.com/16939591/182044517-50fac479-ed69-4632-a193-29d88bb4a0f7.png)

After:
![Screen Shot 2022-07-31 at 4 40 26 PM](https://user-images.githubusercontent.com/16939591/182044521-937351bd-bf08-4c19-a88f-5393b71516f8.png)

This could probably stand to be tweaked more, but I wanted to get a relatively hot fix out in case we have another demo coming up.
